### PR TITLE
Add FHTTPCLient as a runtime dependence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.2.0] - 2023-05-22
+
+- Add FHTTPClient gem as a runtime dependence.
+
 ## [0.1.0] - 2023-02-22
 
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'f_http_client', github: 'Fretadao/f_http_client', branch: 'master'
-  gem 'f_service', github: 'Fretadao/f_service', branch: 'master'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,10 @@
-GIT
-  remote: https://github.com/Fretadao/f_http_client.git
-  revision: 95a2101f0efbac4d93619ff2e21842c74850748d
-  branch: master
-  specs:
-    f_http_client (0.1.0)
-      activesupport
-      addressable
-      dry-configurable
-      dry-initializer
-      httparty
-
-GIT
-  remote: https://github.com/Fretadao/f_service.git
-  revision: 22d3e1c8bd4aa83b14f34b1af19aa4cd22b8ad8b
-  branch: master
-  specs:
-    f_service (0.2.0)
-
 PATH
   remote: .
   specs:
-    rd_station_client (0.1.0)
+    rd_station_client (0.2.0)
       connection_pool
       dry-configurable
+      f_http_client (>= 0.2.0)
       redis
 
 GEM
@@ -50,6 +32,14 @@ GEM
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-initializer (3.1.1)
+    f_http_client (0.2.0)
+      activesupport
+      addressable
+      dry-configurable
+      dry-initializer
+      f_service (>= 0.3.0)
+      httparty
+    f_service (0.3.0)
     hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -132,8 +122,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  f_http_client!
-  f_service!
   pry
   pry-nav
   rake (~> 13.0)

--- a/lib/rd_station_client/version.rb
+++ b/lib/rd_station_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStationClient
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/rd_station_client.gemspec
+++ b/rd_station_client.gemspec
@@ -31,8 +31,10 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_dependency 'connection_pool'
-  spec.add_runtime_dependency 'dry-configurable'
   spec.add_dependency 'redis'
+
+  spec.add_runtime_dependency 'dry-configurable'
+  spec.add_runtime_dependency 'f_http_client', '>= 0.2.0'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
- Add FHTTPClient as runtime dependence instead of using github;
- Creates the version 0.2.0