### PR TITLE
Remove MFA to for new releases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,11 @@ AllCops:
     - '.git/**/*'
     - 'examples/**/*'
 
+##### RUBYGEMS #####
+
+Gemspec/RequireMFA:
+  Enabled: false
+
 ##### LAYOUT #####
 
 Layout/FirstArrayElementIndentation:

--- a/rd_station_client.gemspec
+++ b/rd_station_client.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata['rubygems_mfa_required'] = 'false'
 end


### PR DESCRIPTION
This will allow more people to publish a new gem release instead of only @j133y:

More details at: https://guides.rubygems.org/mfa-requirement-opt-in/

![MFA requirement opt-in - RubyGems Guides](https://github.com/Fretadao/rd_station_client/assets/173159/605a5894-77cf-471a-833b-1bf652770eb2)
